### PR TITLE
include relative RMSE fun

### DIFF
--- a/Performance_rmse_fun.R
+++ b/Performance_rmse_fun.R
@@ -19,6 +19,10 @@ sdm_rmse <- function(dat_hist, dat_fcast) {
     sqrt(mean((p - o)^2))
   }
   
+  RRMSE = function(p, o){
+    sqrt(mean((p - o)^2)) / mean(o)
+  }
+  
   all_mods <- c("gam_E","gam_S","gam_ES","gam_EST","gam_ECor",
                 "brt_E","brt_S","brt_ES","brt_EST",
                 "mlp_E","mlp_S","mlp_ES","mlp_EST",


### PR DESCRIPTION
Could just replace RMSE with RRMSE further down in this code if you want to compare a standardized metric of error among years or across species